### PR TITLE
Fix Communications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 *.autosave
+.idea/workspace.xml

--- a/src/Communication/Communication.cpp
+++ b/src/Communication/Communication.cpp
@@ -1,61 +1,74 @@
 #include "Communication.h"
+#define COMM_SERIAL Serial3
 
-const int8_t ECVT_DATA_SIZE = 37;   // Bytes
+const int8_t ECVT_DATA_SIZE = sizeof(Communication::Data);  // Bytes
 const int8_t START_DATA_SIZE = 2;   // Bytes
 const int8_t CHECK_DATA_SIZE = 2;   // Bytes
 const int8_t START_BYTE_VAL = 0xAA; // 1010 1010
 
-Communication::Communication(FSMVars fsm, Engine engine, Primary primary, Secondary secondary)
-    : Task(fsm), engine(engine), primary(primary), secondary(secondary)
-{
+Communication::Communication(FSMVars fsm, Engine engine, Primary primary, Secondary secondary, volatile bool* writeFlag)
+        : Task(fsm), engine(engine), primary(primary), secondary(secondary), writeFlag(writeFlag) {
     numBytesWritten = 0;
 }
 
-void Communication::run()
-{
-    switch (state)
-    {
-    case INITIALIZE:
-        state = WRITE_START_DATA;
-        return;
+void Communication::run() {
+    switch (state) {
+        case INITIALIZE:
+            state = INIT_WRITE;
+            COMM_SERIAL.begin(9600);
+            return;
 
-    case WRITE_START_DATA:
-        if (fsm.comm)
-        {
-            Serial.write(START_BYTE_VAL);
-            numBytesWritten++;
-        }
-        if (numBytesWritten >= 2)
-        {
-            state = STORE_ECVT_DATA;
-        }
-        return;
+        case INIT_WRITE:
+            numBytesWritten = 0;
+            //Serial.println("Init write");
+            state = WRITE_START_DATA;
+            return;
 
-    case STORE_ECVT_DATA:
-        data.time = micros();
-        // Engine
-        data.engaged = fsm.engaged;
-        data.eState = engine.getState();
-        data.eSpeed = fsm.eSpeed;
-        data.ePID = fsm.ePIDOutput;
-        data.eP = engine.getPID().getP();
-        data.eI = engine.getPID().getI();
-        data.eD = engine.getPID().getD();
-        // Primary
-        data.pState = primary.getState();
-        data.pEnc = primary.getEnc().read();
-        data.pLC = fsm.pLoadCellForce;
-        data.pPID = fsm.pPIDOutput;
-        // Secondary
-        data.sState = secondary.getState();
-        data.sEnc = secondary.getEnc().read();
-        data.sLC = fsm.sLoadCellForce;
-        data.sPID = fsm.sPIDOutput;
+        case WRITE_START_DATA:
+            if (*writeFlag) {
+                //Serial.println("COMM");
 
-        state = WRITE_ECVT_DATA;
-        return;
+                COMM_SERIAL.write(START_BYTE_VAL);
+                numBytesWritten++;
+            }
+            if (numBytesWritten >= 2) {
+                *writeFlag = false;
+                state = STORE_ECVT_DATA;
+            }
+            return;
 
-    case WRITE_ECVT_DATA:
-        return;
+        case STORE_ECVT_DATA:
+            data.time = micros();
+            // Engine
+            data.engaged = fsm.engaged;
+            data.eState = engine.getState();
+            data.eSpeed = fsm.eSpeed;
+            data.ePID = fsm.ePIDOutput;
+            data.eP = engine.getPID().getP();
+            data.eI = engine.getPID().getI();
+            data.eD = engine.getPID().getD();
+            // Primary
+            data.pState = primary.getState();
+            data.pEnc = primary.getEnc().read();
+            data.pLC = fsm.pLoadCellForce;
+            data.pPID = fsm.pPIDOutput;
+            // Secondary
+            data.sState = secondary.getState();
+            data.sEnc = secondary.getEnc().read();
+            data.sLC = fsm.sLoadCellForce;
+            data.sPID = random(0, 100);
+
+            COMM_SERIAL.write((uint8_t * ) &data, ECVT_DATA_SIZE);
+
+            Serial.println("WRITE COMM");
+            state = WRITE_ECVT_DATA;
+            return;
+
+        case WRITE_ECVT_DATA:
+            //Checksum;
+            COMM_SERIAL.write(0xFF);
+            COMM_SERIAL.write(0xFF);
+            state = INIT_WRITE;
+            return;
     }
 }

--- a/src/Communication/Communication.cpp
+++ b/src/Communication/Communication.cpp
@@ -1,61 +1,71 @@
 #include "Communication.h"
 
-const int8_t ECVT_DATA_SIZE = 37;   // Bytes
+#define COMM_SERIAL Serial3
+
+const int8_t ECVT_DATA_SIZE = sizeof(Communication::Data);  // Bytes
 const int8_t START_DATA_SIZE = 2;   // Bytes
 const int8_t CHECK_DATA_SIZE = 2;   // Bytes
 const int8_t START_BYTE_VAL = 0xAA; // 1010 1010
 
 Communication::Communication(FSMVars &fsm, Engine engine, Primary primary, Secondary secondary)
-    : Task(fsm), engine(engine), primary(primary), secondary(secondary)
-{
+        : Task(fsm), engine(engine), primary(primary), secondary(secondary) {
     numBytesWritten = 0;
 }
 
-void Communication::run()
-{
-    switch (state)
-    {
-    case INITIALIZE:
-        state = WRITE_START_DATA;
-        return;
+void Communication::run() {
+    switch (state) {
+        case INITIALIZE:
+            state = INIT_WRITE;
+            COMM_SERIAL.begin(9600);
+            return;
 
-    case WRITE_START_DATA:
-        if (fsm.comm)
-        {
-            Serial.write(START_BYTE_VAL);
-            numBytesWritten++;
-        }
-        if (numBytesWritten >= 2)
-        {
-            state = STORE_ECVT_DATA;
-        }
-        return;
+        case INIT_WRITE:
+            numBytesWritten = 0;
+            state = WRITE_START_DATA;
+            return;
 
-    case STORE_ECVT_DATA:
-        data.time = micros();
-        // Engine
-        data.engaged = fsm.engaged;
-        data.eState = engine.getState();
-        data.eSpeed = fsm.eSpeed;
-        data.ePID = fsm.ePIDOutput;
-        data.eP = engine.getPID().getP();
-        data.eI = engine.getPID().getI();
-        data.eD = engine.getPID().getD();
-        // Primary
-        data.pState = primary.getState();
-        data.pEnc = primary.getEnc().read();
-        data.pLC = fsm.pLoadCellForce;
-        data.pPID = fsm.pPIDOutput;
-        // Secondary
-        data.sState = secondary.getState();
-        data.sEnc = secondary.getEnc().read();
-        data.sLC = fsm.sLoadCellForce;
-        data.sPID = fsm.sPIDOutput;
+        case WRITE_START_DATA:
+            if (fsm.comm) {
+                COMM_SERIAL.write(START_BYTE_VAL);
+                numBytesWritten++;
+            }
+            if (numBytesWritten >= 2) {
+                fsm.comm = false;
+                //Serial.println("WRT");
+                state = STORE_ECVT_DATA;
+            }
+            return;
 
-        state = WRITE_ECVT_DATA;
-        return;
+        case STORE_ECVT_DATA:
+            data.time = micros();
+            // Engine
+            data.engaged = fsm.engaged;
+            data.eState = engine.getState();
+            data.eSpeed = fsm.eSpeed;
+            data.ePID = fsm.ePIDOutput;
+            data.eP = engine.getPID().getP();
+            data.eI = engine.getPID().getI();
+            data.eD = engine.getPID().getD();
+            // Primary
+            data.pState = primary.getState();
+            data.pEnc = primary.getEnc().read();
+            data.pLC = fsm.pLoadCellForce;
+            data.pPID = fsm.pPIDOutput;
+            // Secondary
+            data.sState = secondary.getState();
+            data.sEnc = secondary.getEnc().read();
+            data.sLC = fsm.sLoadCellForce;
+            data.sPID = fsm.sPIDOutput;
 
-    case WRITE_ECVT_DATA:
-        return;
+            COMM_SERIAL.write((uint8_t * ) &data, ECVT_DATA_SIZE);
+            state = WRITE_ECVT_DATA;
+            return;
+
+        case WRITE_ECVT_DATA:
+            //Checksum;
+            COMM_SERIAL.write(0xFF);
+            COMM_SERIAL.write(0xFF);
+            state = INIT_WRITE;
+            return;
     }
 }

--- a/src/Communication/Communication.h
+++ b/src/Communication/Communication.h
@@ -6,34 +6,25 @@
 #include "Primary/Primary.h"
 #include "Secondary/Secondary.h"
 
-class Communication : public Task
-{
+class Communication : public Task {
 public:
-    enum State
-    {
+    enum State {
         INITIALIZE,
         WRITE_START_DATA,
         STORE_ECVT_DATA,
-        WRITE_ECVT_DATA
+        WRITE_ECVT_DATA,
+        INIT_WRITE,
     };
 
     Communication(
-        FSMVars &fsm,
-        Engine engine,
-        Primary primary,
-        Secondary secondary);
+            FSMVars &fsm,
+            Engine engine,
+            Primary primary,
+            Secondary secondary);
 
     void run();
 
-private:
-    State state = INITIALIZE;
-    int8_t numBytesWritten;
-    Engine engine;
-    Primary primary;
-    Secondary secondary;
-
-    struct Data
-    {
+    struct Data {
         uint32_t time;
         // Engine
         bool engaged;
@@ -54,6 +45,13 @@ private:
         int16_t sLC;
         int16_t sPID;
     } data;
+
+private:
+    State state = INITIALIZE;
+    int8_t numBytesWritten;
+    Engine engine;
+    Primary primary;
+    Secondary secondary;
 };
 
 #endif

--- a/src/Communication/Communication.h
+++ b/src/Communication/Communication.h
@@ -6,34 +6,26 @@
 #include "Primary/Primary.h"
 #include "Secondary/Secondary.h"
 
-class Communication : public Task
-{
+class Communication : public Task {
 public:
-    enum State
-    {
+    enum State {
         INITIALIZE,
         WRITE_START_DATA,
         STORE_ECVT_DATA,
-        WRITE_ECVT_DATA
+        WRITE_ECVT_DATA,
+        INIT_WRITE
     };
 
     Communication(
-        FSMVars fsm,
-        Engine engine,
-        Primary primary,
-        Secondary secondary);
+            FSMVars fsm,
+            Engine engine,
+            Primary primary,
+            Secondary secondary,
+            volatile bool *writeFlag);
 
     void run();
 
-private:
-    State state = INITIALIZE;
-    int8_t numBytesWritten;
-    Engine engine;
-    Primary primary;
-    Secondary secondary;
-
-    struct Data
-    {
+    struct Data {
         uint32_t time;
         // Engine
         bool engaged;
@@ -53,7 +45,16 @@ private:
         int32_t sEnc;
         int16_t sLC;
         int16_t sPID;
-    } data;
+    } __attribute__((packed)) data;
+private:
+    State state = INITIALIZE;
+    int8_t numBytesWritten;
+    Engine engine;
+    Primary primary;
+    Secondary secondary;
+    volatile bool *writeFlag;
+
+
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,7 @@ Motor sMot(S_MOT_INA, S_MOT_INB, S_MOT_PWM);
 IntervalTimer ctrlTimer;
 IntervalTimer commTimer;
 const uint32_t CTRL_PERIOD = 10000; // Microseconds (us)
-const uint32_t COMM_PERIOD = 10000; // Microseconds (us)
+const uint32_t COMM_PERIOD = 1000000; // Microseconds (us)
 
 /* ** FINITE STATE MACHINES ** */
 
@@ -258,5 +258,5 @@ void loop()
     // launchControl.run();
     // ecvtstatusLED.run();
     // dashboardLEDs.run();
-    // communication.run();
+    communication.run();
 }


### PR DESCRIPTION
This PR makes a couple changes to communications to fix its operations. It
- Fixes fsm.comm not being reset
- Enables the communication FSM in the main loop
- Sets the proper serial port (Serial2)
- Packs the data struct
- Some other things probably I forgot.

Note: Ben already has these changes Don't merge this if he pushed them.